### PR TITLE
API: Add Pipeline to pangeo_forge namespace

### DIFF
--- a/pangeo_forge/__init__.py
+++ b/pangeo_forge/__init__.py
@@ -1,7 +1,16 @@
 from pkg_resources import DistributionNotFound, get_distribution
 
+from pangeo_forge.pipelines import AbstractPipeline
+
 try:
     __version__ = get_distribution(__name__).version
 except DistributionNotFound:  # noqa: F401
     # package is not installed
     pass
+
+del get_distribution, DistributionNotFound
+
+
+__all__ = [
+    "AbstractPipeline",
+]

--- a/pangeo_forge/pipelines/__init__.py
+++ b/pangeo_forge/pipelines/__init__.py
@@ -1,0 +1,5 @@
+from .base import AbstractPipeline
+
+__all__ = [
+    "AbstractPipeline",
+]


### PR DESCRIPTION
Just to avoid `class Pipeline(pange_forge.pipeline.base.Pipeline):`