### PR TITLE
docs: provide GitHub button to make edits etc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,16 @@ jupyter_execute_notebooks = "off"
 
 # -- Options for HTML output -------------------------------------------------
 
+# https://sphinx-book-theme.readthedocs.io/en/latest/configure.html
 html_theme = "sphinx_book_theme"
+html_theme_options = {
+    "repository_url": "https://github.com/pangeo-forge/pangeo-forge",
+    "repository_branch": "master",
+    "path_to_docs": "docs",
+    "use_repository_button": True,
+    "use_issues_button": True,
+    "use_edit_page_button": True,
+}
 html_logo = "_static/pangeo-forge-logo-blue.png"
 html_static_path = ["_static"]
 myst_heading_anchors = 2


### PR DESCRIPTION
See the top right corner of the [documentation preview](https://pangeo-forge--42.org.readthedocs.build/en/42/), the GitHub button is added as part of this PR.