### PR TITLE
Fix API doc

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -32,7 +32,7 @@
     :show-inheritance:
 ```
 
-## Excutors
+## Executors
 
 ```{eval-rst}
 .. autoclass:: pangeo_forge.executors.PythonPipelineExecutor

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,9 @@
+import sys
+
 # import sphinx_pangeo_theme  # noqa
 import sphinx_book_theme  # noqa
+
+sys.path.append("..")
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,9 +1,5 @@
-import sys
-
 # import sphinx_pangeo_theme  # noqa
 import sphinx_book_theme  # noqa
-
-sys.path.append("..")
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,3 +7,4 @@ sphinx-copybutton
 sphinx-autodoc-typehints
 fsspec
 rechunker
+-e .

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,5 +6,5 @@ myst-nb
 sphinx-copybutton
 sphinx-autodoc-typehints
 fsspec
-rechunker
+git+https://github.com/pangeo-data/rechunker.git
 -e .

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,5 @@ myst-parser
 myst-nb
 sphinx-copybutton
 sphinx-autodoc-typehints
+fsspec
+rechunker

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,5 +6,6 @@ myst-nb
 sphinx-copybutton
 sphinx-autodoc-typehints
 fsspec
+prefect
 git+https://github.com/pangeo-data/rechunker.git
 -e .


### PR DESCRIPTION
Fixes #38

See https://pangeo-forge--46.org.readthedocs.build/en/46/api.html

There are other errors:
```
WARNING: autodoc: failed to import class 'recipe.BaseRecipe' from module 'pangeo_forge'; the following exception was raised:
cannot import name 'MultiStagePipeline' from 'rechunker.types' (/home/david/mambaforge/envs/pangeo-forge-dev/lib/python3.9/site-packages/rechunker/types.py) 
WARNING: autodoc: failed to import class 'recipe.NetCDFtoZarrSequentialRecipe' from module 'pangeo_forge'; the following exception was raised:
cannot import name 'MultiStagePipeline' from 'rechunker.types' (/home/david/mambaforge/envs/pangeo-forge-dev/lib/python3.9/site-packages/rechunker/types.py) 
WARNING: autodoc: failed to import class 'executors.PythonPipelineExecutor' from module 'pangeo_forge'; the following exception was raised:
cannot import name 'DaskPipelineExecutor' from 'rechunker.executors' (/home/david/mambaforge/envs/pangeo-forge-dev/lib/python3.9/site-packages/rechunker/executors/__init__.py)                                                                                                                                           
WARNING: autodoc: failed to import class 'executors.DaskPipelineExecutor' from module 'pangeo_forge'; the following exception was raised:
cannot import name 'DaskPipelineExecutor' from 'rechunker.executors' (/home/david/mambaforge/envs/pangeo-forge-dev/lib/python3.9/site-packages/rechunker/executors/__init__.py)                                                                                                                                           
WARNING: autodoc: failed to import class 'executors.PrefectPipelineExecutor' from module 'pangeo_forge'; the following exception was raised:
cannot import name 'DaskPipelineExecutor' from 'rechunker.executors' (/home/david/mambaforge/envs/pangeo-forge-dev/lib/python3.9/site-packages/rechunker/executors/__init__.py)
```
Indeed, it looks like `MultiStagePipeline` and `DaskPipelineExecutor` don't exist in rechunker.