### PR TITLE
Add fsspec_open_kwargs param to NetCDFtoZarrSequentialRecipe

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ max-line-length = 100
 
 [isort]
 known_first_party=pangeo_forge
-known_third_party=fsspec,numpy,pandas,pkg_resources,prefect,pytest,rechunker,setuptools,sphinx_book_theme,xarray,zarr
+known_third_party=aiohttp,fsspec,numpy,pandas,pkg_resources,prefect,pytest,rechunker,setuptools,sphinx_book_theme,xarray,zarr
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0

--- a/tests/http_auth_server.py
+++ b/tests/http_auth_server.py
@@ -1,0 +1,33 @@
+import base64
+import http.server
+import socketserver
+import sys
+
+port_str, ADDRESS = sys.argv[1:3]
+PORT = int(port_str)
+if len(sys.argv) > 3:
+    username, password = sys.argv[3:5]
+else:
+    username, password = "", ""
+
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def do_GET(self):
+        if username:
+            auth = self.headers.get("Authorization")
+            if (
+                auth is None
+                or not auth.startswith("Basic")
+                or auth[6:]
+                != str(base64.b64encode((username + ":" + password).encode("utf-8")), "utf-8")
+            ):
+                self.send_response(401)
+                self.send_header("WWW-Authenticate", "Basic")
+                self.end_headers()
+                return
+        return http.server.SimpleHTTPRequestHandler.do_GET(self)
+
+
+socketserver.TCPServer.allow_reuse_address = True
+with socketserver.TCPServer((ADDRESS, PORT), Handler) as httpd:
+    httpd.serve_forever()

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -13,7 +13,7 @@ def test_fixture_local_files(daily_xarray_dataset, netcdf_local_paths):
 
 
 def test_fixture_http_files(daily_xarray_dataset, netcdf_http_server):
-    url, paths = netcdf_http_server
+    url, paths = netcdf_http_server()
     urls = ["/".join([url, str(path)]) for path in paths]
     open_files = [fsspec.open(url).open() for url in urls]
     ds = xr.open_mfdataset(open_files, combine="nested", concat_dim="time").load()

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -1,3 +1,4 @@
+import aiohttp
 import pytest
 import xarray as xr
 
@@ -33,6 +34,42 @@ def test_sequence_recipe(file_urls, files_per_chunk, expected_keys, expected_fil
     for k, expected in zip(r.iter_chunks(), expected_filenames):
         fnames = r.inputs_for_chunk(k)
         assert fnames == expected
+
+
+@pytest.mark.parametrize(
+    "username, password", [("foo", "bar"), ("foo", "wrong"),],  # noqa: E231
+)
+def test_NetCDFtoZarrSequentialRecipeHttpAuth(
+    daily_xarray_dataset, netcdf_http_server, tmp_target, tmp_cache, username, password
+):
+
+    url, fnames = netcdf_http_server("foo", "bar")
+    urls = [f"{url}/{fname}" for fname in fnames]
+    r = recipe.NetCDFtoZarrSequentialRecipe(
+        input_urls=urls,
+        sequence_dim="time",
+        inputs_per_chunk=1,
+        nitems_per_input=daily_xarray_dataset.attrs["items_per_file"],
+        target=tmp_target,
+        input_cache=tmp_cache,
+        fsspec_open_kwargs={"client_kwargs": {"auth": aiohttp.BasicAuth(username, password)}},
+    )
+
+    if password == "wrong":
+        with pytest.raises(aiohttp.client_exceptions.ClientResponseError):
+            r.cache_input(next(r.iter_inputs()))
+    else:
+        # this is the cannonical way to manually execute a recipe
+        for input_key in r.iter_inputs():
+            r.cache_input(input_key)
+        r.prepare_target()
+        for chunk_key in r.iter_chunks():
+            r.store_chunk(chunk_key)
+        r.finalize_target()
+
+        ds_target = xr.open_zarr(tmp_target.get_mapper(), consolidated=True).load()
+        ds_expected = daily_xarray_dataset.compute()
+        assert ds_target.identical(ds_expected)
 
 
 def test_NetCDFtoZarrSequentialRecipe(


### PR DESCRIPTION
This allows e.g. HTTP authentication by passing `client_kwargs={'auth': aiohttp.BasicAuth('username', 'password')}` to `HTTPFileSystem`:
```python
recipe = NetCDFtoZarrSequentialRecipe(
    input_urls=input_urls,
    sequence_dim="time",
    inputs_per_chunk=4,
    fsspec_open_kwargs={'client_kwargs': {'auth': aiohttp.BasicAuth('username', 'password')}}
)
```
See https://github.com/pangeo-forge/pangeo-forge/issues/53#issuecomment-766397594

fixes #53 