### PR TITLE
Write with Zarr

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: install pangeo-forge
         shell: bash -l {0}
         run: |
-          python -m pip install -e --no-deps .
+          python -m pip install --no-deps -e  .
       - name: Run Tests
         shell: bash -l {0}
         run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: install pangeo-forge
         shell: bash -l {0}
         run: |
-          python -m pip install -e .
+          python -m pip install -e --no-deps .
       - name: Run Tests
         shell: bash -l {0}
         run: |

--- a/ci/py3.7.yml
+++ b/ci/py3.7.yml
@@ -34,3 +34,4 @@ dependencies:
     - git+https://github.com/rabernat/xarray.git@zarr-chunk-fixes
     - git+https://github.com/pangeo-data/rechunker.git@master
     - git+https://github.com/intake/filesystem_spec.git@master
+    - fsspec[http]

--- a/ci/py3.7.yml
+++ b/ci/py3.7.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.7
+  - aiohttp
   - black
   - boto3
   - cfgrib
@@ -25,6 +26,7 @@ dependencies:
   - pytest-cov
   - pytest-lazy-fixture
   - rasterio
+  - requests
   - scipy
   - setuptools
   - toolz
@@ -34,4 +36,3 @@ dependencies:
     - git+https://github.com/rabernat/xarray.git@zarr-chunk-fixes
     - git+https://github.com/pangeo-data/rechunker.git@master
     - git+https://github.com/intake/filesystem_spec.git@master
-    - fsspec[http]

--- a/ci/py3.7.yml
+++ b/ci/py3.7.yml
@@ -28,8 +28,9 @@ dependencies:
   - scipy
   - setuptools
   - toolz
-  - xarray>=0.16.2
+#  - xarray>=0.16.2
   - zarr>=2.6.0
   - pip:
+    - git+https://github.com/rabernat/xarray.git@zarr-chunk-fixes
     - git+https://github.com/pangeo-data/rechunker.git@master
     - git+https://github.com/intake/filesystem_spec.git@master

--- a/ci/py3.8.yml
+++ b/ci/py3.8.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.8
+  - aiohttp
   - black
   - boto3
   - cfgrib
@@ -25,6 +26,7 @@ dependencies:
   - pytest-cov
   - pytest-lazy-fixture
   - rasterio
+  - requests
   - scipy
   - setuptools
   - toolz
@@ -34,4 +36,3 @@ dependencies:
     - git+https://github.com/rabernat/xarray.git@zarr-chunk-fixes
     - git+https://github.com/pangeo-data/rechunker.git@master
     - git+https://github.com/intake/filesystem_spec.git@master
-    - fsspec[http]

--- a/ci/py3.8.yml
+++ b/ci/py3.8.yml
@@ -34,3 +34,4 @@ dependencies:
     - git+https://github.com/rabernat/xarray.git@zarr-chunk-fixes
     - git+https://github.com/pangeo-data/rechunker.git@master
     - git+https://github.com/intake/filesystem_spec.git@master
+    - fsspec[http]

--- a/ci/py3.8.yml
+++ b/ci/py3.8.yml
@@ -28,8 +28,9 @@ dependencies:
   - scipy
   - setuptools
   - toolz
-  - xarray>=0.16.2
+#  - xarray>=0.16.2
   - zarr>=2.6.0
   - pip:
+    - git+https://github.com/rabernat/xarray.git@zarr-chunk-fixes
     - git+https://github.com/pangeo-data/rechunker.git@master
     - git+https://github.com/intake/filesystem_spec.git@master

--- a/ci/py3.9.yml
+++ b/ci/py3.9.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.9
+  - aiohttp
   - black
   - boto3
   - cfgrib
@@ -26,6 +27,7 @@ dependencies:
   - pytest-cov
   - pytest-lazy-fixture
   - rasterio
+  - requests
   - scipy
   - setuptools
   - toolz
@@ -35,4 +37,3 @@ dependencies:
     - git+https://github.com/rabernat/xarray.git@zarr-chunk-fixes
     - git+https://github.com/pangeo-data/rechunker.git@master
     - git+https://github.com/intake/filesystem_spec.git@master
-    - fsspec[http]

--- a/ci/py3.9.yml
+++ b/ci/py3.9.yml
@@ -35,3 +35,4 @@ dependencies:
     - git+https://github.com/rabernat/xarray.git@zarr-chunk-fixes
     - git+https://github.com/pangeo-data/rechunker.git@master
     - git+https://github.com/intake/filesystem_spec.git@master
+    - fsspec[http]

--- a/ci/py3.9.yml
+++ b/ci/py3.9.yml
@@ -29,8 +29,9 @@ dependencies:
   - scipy
   - setuptools
   - toolz
-  - xarray>=0.16.2
+#  - xarray>=0.16.2
   - zarr>=2.6.0
   - pip:
+    - git+https://github.com/rabernat/xarray.git@zarr-chunk-fixes
     - git+https://github.com/pangeo-data/rechunker.git@master
     - git+https://github.com/intake/filesystem_spec.git@master

--- a/pangeo_forge/recipe.py
+++ b/pangeo_forge/recipe.py
@@ -411,15 +411,10 @@ class NetCDFtoZarrRecipe(BaseRecipe):
         # need to open an unknown number of contexts at the same time
         with ExitStack() as stack:
             dsets = [stack.enter_context(self.open_input(i)) for i in inputs]
-            dsets = [ds.chunk() for ds in dsets]
-
             # explicitly chunking prevents eager evaluation during concat
-            # dsets = [ds.chunk() for ds in dsets]
-            # but that leads to corrupted data!
-
-            # CONCAT DELETES ENCODING!!!
-            # OR NO IT DOESN'T! Not in the latest version of xarray?
+            dsets = [ds.chunk() for ds in dsets]
             if len(dsets) > 1:
+                # TODO: check what happens to encoding and attributes during concat
                 ds = xr.concat(dsets, self.sequence_dim, **self.xarray_concat_kwargs)
             elif len(dsets) == 1:
                 ds = dsets[0]

--- a/pangeo_forge/recipe.py
+++ b/pangeo_forge/recipe.py
@@ -258,7 +258,9 @@ class NetCDFtoZarrRecipe(BaseRecipe):
                                 encoding_chunks = chunks
                             else:
                                 encoding_chunks = ds[v].shape
-                            logger.debug(f"Setting variable {v} encoding chunks to {encoding_chunks}")
+                            logger.debug(
+                                f"Setting variable {v} encoding chunks to {encoding_chunks}"
+                            )
                             ds[v].encoding["chunks"] = encoding_chunks
 
                         # load all variables that don't have the sequence dim in them
@@ -341,7 +343,7 @@ class NetCDFtoZarrRecipe(BaseRecipe):
                         )  # TODO: can we buffer large data rather than loading it all?
                     zarr_region = tuple(write_region.get(dim, slice(None)) for dim in var.dims)
                     lock_keys = [f"{vname}-{c}" for c in conflicts]
-                    logger.debug(f'Acquiring locks {lock_keys}')
+                    logger.debug(f"Acquiring locks {lock_keys}")
                     with lock_for_conflicts(lock_keys):
                         logger.info(
                             f"Storing variable {vname} chunk {chunk_key} "

--- a/pangeo_forge/recipe.py
+++ b/pangeo_forge/recipe.py
@@ -424,7 +424,8 @@ class NetCDFtoZarrRecipe(BaseRecipe):
             # explicitly chunking prevents eager evaluation during concat
             dsets = [ds.chunk() for ds in dsets]
             if len(dsets) > 1:
-                # TODO: check what happens to encoding and attributes during concat
+                # During concat, attributes and encoding are taken from the first dataset
+                # https://github.com/pydata/xarray/issues/1614
                 ds = xr.concat(dsets, self.sequence_dim, **self.xarray_concat_kwargs)
             elif len(dsets) == 1:
                 ds = dsets[0]

--- a/tests/test_locking.py
+++ b/tests/test_locking.py
@@ -1,0 +1,79 @@
+"""
+Tests for our custom array writing locking stuff.
+"""
+
+import logging
+import sys
+from time import sleep
+
+import dask
+import numpy as np
+import pytest
+import zarr
+from dask.distributed import Client
+
+from pangeo_forge.utils import chunk_bounds_and_conflicts, lock_for_conflicts
+
+
+@pytest.mark.parametrize("n_tasks, conflicts", [(2, (0,)), (2, (1, 2)), (4, (0,))])
+def test_locks(n_tasks, conflicts, tmp_target, dask_cluster):
+
+    this_client = Client(dask_cluster)
+
+    @dask.delayed
+    def do_stuff(n):
+        logger = logging.getLogger("pangeo_forge")
+        handler = logging.StreamHandler(stream=sys.stdout)
+        handler.setLevel(logging.DEBUG)
+        logger.addHandler(handler)
+        with lock_for_conflicts(conflicts):
+            # test for concurrency by writing an object and asserting there are
+            # no other objects present
+            mapper = tmp_target.get_mapper()
+            key = f"foo_{n}"
+            mapper[key] = b"bar"
+            assert list(mapper) == [key]
+            sleep(0.25)
+            del mapper[key]
+            assert list(mapper) == []
+
+    dask.compute([do_stuff(n) for n in range(n_tasks)])
+
+    this_client.close()
+    del this_client
+
+
+# chunking is always over first dimension
+@pytest.mark.parametrize(
+    "shape, zarr_chunks, write_chunks",
+    [
+        ((100,), (10,), (15,)),  # just a few conflicts
+        ((100,), (100,), (10,)),  # lots of conflicts!
+    ],
+)
+def test_locked_array_writing(shape, zarr_chunks, write_chunks, tmp_target, dask_cluster):
+
+    sequence_lens = (shape[0] // write_chunks[0]) * [write_chunks[0]]
+    remainder = shape[0] % write_chunks[0]
+    if remainder > 0:
+        sequence_lens.append(remainder)
+
+    chunk_bounds, chunk_conflicts = chunk_bounds_and_conflicts(sequence_lens, zarr_chunks[0])
+
+    data = np.random.rand(*shape)
+
+    mapper = tmp_target.get_mapper()
+    zarr_array = zarr.open(mapper, mode="w", shape=shape, chunks=zarr_chunks, dtype=data.dtype)
+
+    @dask.delayed
+    def write_block(n):
+        write_region = slice(chunk_bounds[n], chunk_bounds[n + 1])
+        with lock_for_conflicts(chunk_conflicts[n]):
+            zarr_array[write_region] = data[write_region]
+
+    this_client = Client(dask_cluster)
+    dask.compute([write_block(n) for n in range(len(sequence_lens))])
+    np.testing.assert_equal(data, zarr_array)
+
+    this_client.close()
+    del this_client

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -64,6 +64,7 @@ def test_process(recipe_fixture, execute_recipe, process_input, process_chunk):
         ({"lon": 12}, True, does_not_raise()),
         ({"lon": 12, "time": 1}, True, does_not_raise()),
         ({"lon": 12, "time": 3}, True, does_not_raise()),
+        ({"time": 100}, True, does_not_raise()),  # only one big chunk
         ({"lon": 12, "time": 1}, False, does_not_raise()),
         ({"lon": 12, "time": 3}, False, does_not_raise()),
         # can't determine target chunks for the next two because 'time' missing from target_chunks
@@ -116,4 +117,5 @@ def test_chunks(
         assert all([item == chunk_len for item in ds_actual.chunks[other_dim][:-1]])
 
     ds_actual.load()
+    print(ds_actual)
     xr.testing.assert_identical(ds_actual, ds_expected)

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -66,7 +66,7 @@ def test_process(recipe_fixture, execute_recipe, process_input, process_chunk):
         ({"lon": 12, "time": 3}, True, does_not_raise()),
         ({"lon": 12, "time": 1}, False, does_not_raise()),
         ({"lon": 12, "time": 3}, False, does_not_raise()),
-        # can't determine target chunks for the next two because # 'time' missing from target_chunks
+        # can't determine target chunks for the next two because 'time' missing from target_chunks
         ({}, False, pytest.raises(ValueError)),
         ({"lon": 12}, False, pytest.raises(ValueError)),
     ],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,4 @@
-import dask
 import pytest
-from dask import delayed
-from dask.distributed import Client, LocalCluster
 
 from pangeo_forge import utils
 
@@ -26,25 +23,3 @@ def test_chunk_conflicts():
     assert utils.calc_chunk_conflicts([9, 10], zchunks) == [(0,), (0,)]
     assert utils.calc_chunk_conflicts([10, 9, 11, 10], zchunks) == [(), (1,), (1,), ()]
     assert utils.calc_chunk_conflicts([9, 12, 5], zchunks) == [(0,), (0, 2), (2,)]
-
-
-@pytest.mark.parametrize("conflicts", [{}, {0}, {0, 1}])
-def test_locks(conflicts):
-
-    # first make sure the locks work without a cluster
-    with utils.lock_for_conflicts(conflicts):
-        # todo; how to actually test for concurrency! hard!
-        pass
-
-    # TOOD: move this into a fixture
-    with LocalCluster(n_workers=1, processes=False, threads_per_worker=1,) as cluster, Client(
-        cluster
-    ):
-
-        @delayed
-        def do_stuff():
-            with utils.lock_for_conflicts(conflicts):
-                # todo; how to actually test for concurrency! hard!
-                pass
-
-        dask.compute([do_stuff() for n in range(3)])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pangeo_forge import utils
+from pangeo_forge.utils import chunk_bounds_and_conflicts, chunked_iterable
 
 
 @pytest.mark.parametrize(
@@ -13,13 +13,16 @@ from pangeo_forge import utils
     ],
 )
 def test_chunked_iterable(iterable, size, expected):
-    actual = list(utils.chunked_iterable(iterable, size))
+    actual = list(chunked_iterable(iterable, size))
     assert actual == expected
 
 
 def test_chunk_conflicts():
     zchunks = 10
-    assert utils.calc_chunk_conflicts([10, 10], zchunks) == [(), ()]
-    assert utils.calc_chunk_conflicts([9, 10], zchunks) == [(0,), (0,)]
-    assert utils.calc_chunk_conflicts([10, 9, 11, 10], zchunks) == [(), (1,), (1,), ()]
-    assert utils.calc_chunk_conflicts([9, 12, 5], zchunks) == [(0,), (0, 2), (2,)]
+    assert chunk_bounds_and_conflicts([10, 10], zchunks) == ([0, 10, 20], [(), ()])
+    assert chunk_bounds_and_conflicts([9, 10], zchunks) == ([0, 9, 19], [(0,), (0,)])
+    assert chunk_bounds_and_conflicts([10, 9, 11, 10], zchunks) == (
+        [0, 10, 19, 30, 40],
+        [(), (1,), (1,), ()],
+    )
+    assert chunk_bounds_and_conflicts([9, 12, 5], zchunks) == ([0, 9, 21, 26], [(0,), (0, 2), (2,)])


### PR DESCRIPTION
In debugging some real-world use cases (e.g. https://github.com/pangeo-forge/staged-recipes/issues/23), I realized that our current way of writing suffers from some performance bottlenecks. Specifically, when calling `xr.to_zarr` from each `store_chunk` task, the entire dataset has to be read AND dimension coordinates have to be loaded. This translates into 1000s of gcsfs calls. This is particularly bad for the `time` dimension, which is a dimension coordinate but is chunked in time.

The solution, proposed by @TomAugspurger in https://discourse.pangeo.io/t/netcdf-to-zarr-best-practices/1119, is to bypass zarr for writing individual chunks. (I still use it to set up the dataset.) This gives us the best of both worlds.