### PR TITLE
Add copy_input_to_local_file option

### DIFF
--- a/pangeo_forge/recipe.py
+++ b/pangeo_forge/recipe.py
@@ -169,11 +169,8 @@ def _fsspec_safe_open(fname, **kwargs):
     # workaround for inconsistent behavior of fsspec.open
     # https://github.com/intake/filesystem_spec/issues/579
     with fsspec.open(fname, **kwargs) as fp:
-        if isinstance(fp, fsspec.implementations.local.LocalFileOpener):
-            with fp as fp2:
-                yield fp2
-        else:
-            yield fp
+        with fp as fp2:
+            yield fp2
 
 
 # Notes about dataclasses:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -257,8 +257,9 @@ def execute_recipe(request, dask_cluster):
     if request.param == "manual":
 
         def execute(r):
-            for input_key in r.iter_inputs():
-                r.cache_input(input_key)
+            if r.cache_inputs:
+                for input_key in r.iter_inputs():
+                    r.cache_input(input_key)
             r.prepare_target()
             for chunk_key in r.iter_chunks():
                 r.store_chunk(chunk_key)

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -23,6 +23,22 @@ def test_recipe(recipe_fixture, execute_recipe):
     xr.testing.assert_identical(ds_actual, ds_expected)
 
 
+@pytest.mark.parametrize("cache_inputs", [True, False])
+@pytest.mark.parametrize("copy_input_to_local_file", [True, False])
+def test_recipe_caching_copying(
+    netCDFtoZarr_sequential_recipe, execute_recipe, cache_inputs, copy_input_to_local_file
+):
+    """The basic recipe test. Use this as a template for other tests."""
+
+    RecipeClass, kwargs, ds_expected, target = netCDFtoZarr_sequential_recipe
+    rec = RecipeClass(
+        **kwargs, cache_inputs=cache_inputs, copy_input_to_local_file=copy_input_to_local_file
+    )
+    execute_recipe(rec)
+    ds_actual = xr.open_zarr(target.get_mapper()).load()
+    xr.testing.assert_identical(ds_actual, ds_expected)
+
+
 # function passed to preprocessing
 def incr_date(ds, filename=""):
     # add one day


### PR DESCRIPTION
This PR makes two changes:

- Rename `require_cache` option to `cache_inputs`. If this option is False, then the pipeline generation now skips the `cache_input` loop entirely.
- Add an `copy_input_to_local_file`. This causes the input to be copied to a **local** temporary file before opening. This will enable us to open files that have to be opened via a local path (e.g. GRIB, #41) rather than a file-like object.

I swear the tests pass on my local machine, but I assume they will time out in CI.