### PR TITLE
Refactor method wrappers

### DIFF
--- a/pangeo_forge/recipes/base.py
+++ b/pangeo_forge/recipes/base.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from functools import partial
 from typing import Callable, Hashable, Iterable
 
 from rechunker.types import MultiStagePipeline, ParallelPipelines, Stage
@@ -93,3 +94,20 @@ class BaseRecipe(ABC):
         # just intercept the __post_init__ calls so they
         # aren't relayed to `object`
         pass
+
+
+def closure(func: Callable) -> Callable:
+    """Wrap a method to eliminate the self keyword from its signature."""
+
+    # tried using @functools.wraps, but could not get it to work right
+    def wrapped(*args, **kwargs):
+        self = args[0]
+        if len(args) > 1:
+            args = args[1:]
+        else:
+            args = ()
+        new_func = partial(func, self, *args, **kwargs)
+        new_func.__name__ = getattr(func, "__name__", None)
+        return new_func
+
+    return wrapped

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -242,9 +242,6 @@ _executors = {
 
 @pytest.fixture(params=["manual", "python", "dask", "prefect", "prefect-dask"])
 def execute_recipe(request, dask_cluster):
-    if request.param == "prefect-dask":
-        # TODO: turn this off and fix this case!
-        pytest.skip("Prefect with dask LocalCluster hangs inexplicably.")
 
     if request.param == "manual":
 


### PR DESCRIPTION
This is an internal refactor that allows us to reduce the level of nesting in our function defintions.

There could be an even simpler way to do this that requires no decorators at all in the class. We might be able to move all the wrapping into the `to_pipelines` method. But I couldn't figure out how to make `functools.partial` work on a bound method (to factor out the `self` argument) without using the decorator approach.