### PR TITLE
Pin xarray to unreleased master and rechunker to 0.4.2 for use with pip.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ setuptools
 click
 dask
 distributed
-rechunker
-xarray
+rechunker==0.4.2
+xarray@git+https://github.com/pydata/xarray
 zarr >= 2.6.0
 fsspec[http]


### PR DESCRIPTION
Closes #111 